### PR TITLE
Ipython extension

### DIFF
--- a/pyrthon/__init__.py
+++ b/pyrthon/__init__.py
@@ -1,5 +1,6 @@
 import sys
 import pyrthon._import_hook as import_hook
+from pyrthon.pyrthon_extension import load_ipython_extension,  unload_ipython_extension
 
 
 def register(*matchers):

--- a/pyrthon/pyrthon_extension.py
+++ b/pyrthon/pyrthon_extension.py
@@ -1,0 +1,14 @@
+from pyrthon._transformer import PyrsistentTransformer
+
+def load_ipython_extension(ipython):
+    ''' load extension for prython in ipython'''
+    pyr_transform = PyrsistentTransformer()
+    ipython.ast_transformers.append(pyr_transform)
+    print("'pyrthon' extension loaded ")
+
+def unload_ipython_extension(ipython):
+    ''' unload the pyrthon ipython extension'''
+    ipython.ast_transformers = [transformer 
+            for transformer in ipython.ast_transformers 
+            if not isinstance(transformer, PyrsistentTransformer)]
+    print("'pyrthon' extension unloaded")

--- a/tests/test_load_extension.ipynb
+++ b/tests/test_load_extension.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'pyrthon' extension loaded \n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext pyrthon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pvectorc.PVector"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type([])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pyrsistent._pmap.PMap"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type({})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pyrsistent._pset.PSet"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type({'a'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'pyrthon' extension unloaded\n"
+     ]
+    }
+   ],
+   "source": [
+    "%unload_ext pyrthon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type([])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type({})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "set"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type({'a'})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I have added the necessary hooks to load `pyrthon` in an ipython notebook or console.  This is accomplished by running the following line from the console or in a notebook cell.

``` python
%load_ext pyrthon
```

I am not sure how you want to handle testing (and TBH I am a novice at testing IPython extensions).  Included is `tests\test_load_extension.ipynb` which can be used to test the functionality of the extension as follows:

``` bash
pip install nbval
py.test --nbval tests/test_load_extension.ipynb
```
(Run from the the project root.)